### PR TITLE
Use `Buffer.from` instead of deprecated `new Buffer(val)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function encryptSync(plainPassword, config) {
     // Hash buffer
     let hash = crypto.pbkdf2Sync(plainPassword, salt, config.iterations, config.hashSize, config.digest);
     // The digest used to hash the password
-    let digest = new Buffer(config.digest);
+    let digest = Buffer.from(config.digest);
 
     // The combined buffer size
     let combined = Buffer.alloc(4 + 4 + 4 + 4 + salt.length + hash.length + digest.length);
@@ -105,7 +105,7 @@ function compare(plainPassword, encryptedPassword) {
  * @returns True if match, otherwise false.
  **/
 function compareSync(plainPassword, encryptedPassword) {
-    let hashBuffer = new Buffer(encryptedPassword, 'hex');
+    let hashBuffer = Buffer.from(encryptedPassword, 'hex');
 
     let saltlength = hashBuffer.readUInt32BE(0);
     let iterations = hashBuffer.readUInt32BE(4);


### PR DESCRIPTION
`new Buffer(val)` was deprecated in node v6.
![image](https://user-images.githubusercontent.com/387256/28370875-22e0fa76-6ca4-11e7-9e73-6cb099f51eda.png)
https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html